### PR TITLE
Add CI workflow and script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint script
+        run: bash -n ./scripts/run_one_command.sh
+      - name: Run one-command script
+        run: bash ./scripts/run_one_command.sh
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.os }}
+          path: build/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 NICNAC16
 ========
 
+[![CI](https://github.com/USER/NICNAC16-FPGA/actions/workflows/ci.yml/badge.svg)](https://github.com/USER/NICNAC16-FPGA/actions/workflows/ci.yml)
+
 Learning FPGAs, starting with a 16-bit CPU design
 
 See [instruction_set.md](docs/instruction_set.md) for details on the instruction set.

--- a/scripts/run_one_command.sh
+++ b/scripts/run_one_command.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+echo "Running NICNAC16 one-command script"
+mkdir -p build
+echo "This is a placeholder build artifact." > build/artifact.txt
+echo "Done"


### PR DESCRIPTION
## Summary
- add a CI workflow running on Ubuntu and Windows
- add a simple one-command script producing an artifact
- show workflow badge in README

## Testing
- `bash -n scripts/run_one_command.sh`