### PR TITLE
Improve setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ See [instruction_set.md](docs/instruction_set.md) for details on the instruction
 
 ![simulation, with NOP, LDA, ADD and JMP x working](pictures/dunc16sim003.png)
 
+## Setup
+
+Install the required build tools (g++, make, cppcheck and iverilog) using the provided script:
+
+```sh
+./setup.sh
+```
+
+
 ## Build and Test
 
 Run the default Makefile target to lint the HDL sources, execute the Memory testbench and create build artifacts:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+missing=()
+for cmd in g++ make cppcheck iverilog; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    missing+=("$cmd")
+  fi
+done
+
+if [[ ${#missing[@]} -ne 0 ]]; then
+  echo "Installing packages: ${missing[*]}"
+  sudo apt-get update -y
+  sudo apt-get install -y g++ make cppcheck iverilog
+fi
+
+for cmd in g++ make cppcheck iverilog; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd not installed" >&2
+    exit 1
+  fi
+done
+
+echo "All required packages are installed."


### PR DESCRIPTION
## Summary
- ensure the setup script also installs iverilog
- document all dependencies in the README

## Testing
- `make lint test` *(fails: `iverilog not installed`)*