### PR TITLE
Add ASIC flow stubs and OpenLane setup

### DIFF
--- a/asic_flow/README.md
+++ b/asic_flow/README.md
@@ -1,0 +1,5 @@
+# ASIC Flow
+
+This directory contains the initial setup for running an ASIC implementation of the NICNAC16 project using OpenLane and the SKY130 PDK.
+
+The provided files are stubs and should be expanded with actual configuration options and scripts required for your design.

--- a/asic_flow/config.tcl
+++ b/asic_flow/config.tcl
@@ -1,0 +1,7 @@
+# OpenLane configuration for NICNAC16 ASIC flow
+# This file is a stub and should be expanded with full design settings
+
+set ::env(PDK) "sky130A"
+set ::env(STD_CELL_LIBRARY) "sky130_fd_sc_hd"
+
+# TODO: add additional OpenLane options

--- a/asic_flow/run_openlane.sh
+++ b/asic_flow/run_openlane.sh
@@ -10,5 +10,7 @@ if ! command -v openlane >/dev/null 2>&1; then
 fi
 
 # Placeholder invocation of OpenLane
-openlane "$SCRIPT_DIR/.." -config "$SCRIPT_DIR/config.tcl" || \
-    echo "OpenLane run script is a stub."
+openlane "$SCRIPT_DIR/.." -config "$SCRIPT_DIR/config.tcl" || { 
+    echo "OpenLane run script is a stub."; 
+    exit 1; 
+}

--- a/asic_flow/run_openlane.sh
+++ b/asic_flow/run_openlane.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Stub script to run OpenLane flow for NICNAC16
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v openlane >/dev/null 2>&1; then
+    echo "OpenLane is not installed or not in PATH" >&2
+    exit 1
+fi
+
+# Placeholder invocation of OpenLane
+openlane "$SCRIPT_DIR/.." -config "$SCRIPT_DIR/config.tcl" || \
+    echo "OpenLane run script is a stub."

--- a/setup.sh
+++ b/setup.sh
@@ -3,23 +3,39 @@ set -e
 
 missing=()
 
-for cmd in g++ make cppcheck iverilog; do
+# Commands required for the FPGA and ASIC flows
+required_cmds=(g++ make cppcheck iverilog openlane)
+
+# Check for command line tools
+for cmd in "${required_cmds[@]}"; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     missing+=("$cmd")
   fi
 done
 
+# Check for the SKY130 PDK installation
+if [ ! -d "/usr/share/pdk/sky130A" ]; then
+  missing+=(sky130-pdk)
+fi
+
 if [[ ${#missing[@]} -ne 0 ]]; then
   echo "Installing packages: ${missing[*]}"
   sudo apt-get update -y
-  sudo apt-get install -y g++ make cppcheck iverilog
+  sudo apt-get install -y g++ make cppcheck iverilog openlane sky130-pdk
 fi
 
-for cmd in g++ make cppcheck iverilog; do
+# Verify command line tools
+for cmd in "${required_cmds[@]}"; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "Error: $cmd not installed" >&2
     exit 1
   fi
 done
+
+# Verify SKY130 PDK directory
+if [ ! -d "/usr/share/pdk/sky130A" ]; then
+  echo "Error: SKY130 PDK not installed" >&2
+  exit 1
+fi
 
 echo "All required packages are installed."


### PR DESCRIPTION
## Summary
- create new `asic_flow` directory
- add stub OpenLane config, run script, and README
- extend `setup.sh` to install OpenLane and SKY130 PDK

## Testing
- `make lint` *(fails: Scalar port ``A'' has a vectored net declaration [15:0])*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683ae9f13a6c83329e66470fa592df99