### PR TITLE
Fix ring counter testbench

### DIFF
--- a/vivado_proj/Basys-3-GPIO.srcs/sim_1/new/ring_counter_tb.v
+++ b/vivado_proj/Basys-3-GPIO.srcs/sim_1/new/ring_counter_tb.v
@@ -40,9 +40,10 @@ module ring_counter_tb;
 	#5 reset = 1;
 	icynext = 1;
 	#20 reset = 0;
-	#5 icynext = 0; 
-	
-    end  
+        #5 icynext = 0;
+        #1000 $finish;
+
+    end
  
 		initial begin
           $monitor($time, " clock=%1b,reset=%1b,q=%4b",clock,reset,q);


### PR DESCRIPTION
## Summary
- end simulation after a delay in `ring_counter_tb.v`
- ensure the file ends with a newline

## Testing
- `od -c -A n -v vivado_proj/Basys-3-GPIO.srcs/sim_1/new/ring_counter_tb.v | tail -n 3`

------
https://chatgpt.com/codex/tasks/task_e_682937e3b3988332a221f76eb8ac0b26