### PR TITLE
FPGA-102 Clean up Stages.v logic and fix width mismatch

### DIFF
--- a/asic_flow/designs/nicnac16_cpu/src/Stages.v
+++ b/asic_flow/designs/nicnac16_cpu/src/Stages.v
@@ -17,9 +17,7 @@ module two_bit_ring_counter (
  
       else
       if (enable)
-      //TODO this can be simplified by using d as a bit in the assignments
-      if (1'b1) //TODO d
-      //if (d)
+      if (d)
           case (a)
            2'b00: a <= 2'b01; // happens only on reset
            2'b01: a <= 2'b10;

--- a/rtl/core/cpu/control/Stages.v
+++ b/rtl/core/cpu/control/Stages.v
@@ -13,13 +13,11 @@ module two_bit_ring_counter (
  
     always @(posedge clock)
       if (reset)
-        a <= 4'b01;
- 
+        a <= 2'b01;
+
       else
       if (enable)
-      //TODO this can be simplified by using d as a bit in the assignments
-      if (1'b1) //TODO d
-      //if (d)
+      if (d)
           case (a)
            2'b00: a <= 2'b01; // happens only on reset
            2'b01: a <= 2'b10;

--- a/src/utils/Stages.v
+++ b/src/utils/Stages.v
@@ -13,13 +13,11 @@ module two_bit_ring_counter (
  
     always @(posedge clock)
       if (reset)
-        a <= 4'b01;
- 
+        a <= 2'b01;
+
       else
       if (enable)
-      //TODO this can be simplified by using d as a bit in the assignments
-      if (1'b1) //TODO d
-      //if (d)
+      if (d)
           case (a)
            2'b00: a <= 2'b01; // happens only on reset
            2'b01: a <= 2'b10;

--- a/vivado_proj/Basys-3-GPIO.srcs/sources_1/new/Stages.v
+++ b/vivado_proj/Basys-3-GPIO.srcs/sources_1/new/Stages.v
@@ -13,13 +13,11 @@ module two_bit_ring_counter (
  
     always @(posedge clock)
       if (reset)
-        a <= 4'b01;
- 
+        a <= 2'b01;
+
       else
       if (enable)
-      //TODO this can be simplified by using d as a bit in the assignments
-      if (1'b1) //TODO d
-      //if (d)
+      if (d)
           case (a)
            2'b00: a <= 2'b01; // happens only on reset
            2'b01: a <= 2'b10;


### PR DESCRIPTION
## Summary

- Replaced `if (1'b1)` with `if (d)` in `two_bit_ring_counter` to properly use the `d` input signal, which controls whether the ring counter wraps (d=1) or stops (d=0)
- Fixed `4'b01` width mismatch to `2'b01` for the 2-bit register `a` in three copies (rtl, src, vivado)
- Removed stale TODO comments that described the fix
- Applied consistently across all 4 copies of Stages.v

Fixes #102

-- Claude